### PR TITLE
fix: Prevent crash on keyboard changes

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation"
             android:name=".MainActivity"
             android:label="${title_activity_main}"
             android:theme="@style/AppTheme.NoActionBarLaunch"


### PR DESCRIPTION
Some Android devices restart activities on keyboard connection/disconnection if `navigation` is not present on the `configChanges` section